### PR TITLE
Fixes input handling for Lingo

### DIFF
--- a/scripts/lingo.rb
+++ b/scripts/lingo.rb
@@ -13,7 +13,7 @@ module Lingo
 
         params = data.text.split(' ')
         toLanguage = params[-1]
-        toTranslate = data.text.split(' en ')[0].split("enerbot como se dice ")[1]
+        toTranslate = data.text.split(' en: ')[0].split("enerbot como se dice ")[1]
 
         if languages.keys.include? toLanguage and not toTranslate.to_s.empty?
             url = "https://translate.googleapis.com/translate_a/single?client=gtx&sl=es&tl=" + languages[toLanguage] + "&dt=t&q=" + URI::encode(toTranslate)

--- a/scripts/lingo.rb
+++ b/scripts/lingo.rb
@@ -5,20 +5,23 @@ require 'uri'
 module Lingo
   
     def self.translate(data)
-        languages =  {"ingles" => "en", "español" => "es", "frances" => "fr", "portugues" => "pt", "ruso" => "ru",
+        languages =  {"ingles" => "en", "español" => "es", "frances" => "fr", "portugues" => "pt", "ruso" => "ru", "aleman" => "de",
             "chino" => "zh", "japones" => "ja", "italiano" => "it", "argentino" => "es", "chileno" => "es", "brasileño" => "pt"}
 
-        flags =  {"ingles" => ":uk:", "español" => ":es:", "frances" => ":fr:", "portugues" => ":flag-pt:", "ruso" => ":ru:",
+        flags =  {"ingles" => ":uk:", "español" => ":es:", "frances" => ":fr:", "portugues" => ":flag-pt:", "ruso" => ":ru:", "aleman" => ":de:",
             "chino" => ":flag-cn:", "japones" => ":jp:", "italiano" => ":it:", "argentino" => ":ar:", "chileno" => ":flag-cl:", "brasileño" => ":flag-br:"}
 
-        params = data.split(' en ')
-        if languages.keys.include? params[1]
-            url = "https://translate.googleapis.com/translate_a/single?client=gtx&sl=es&tl=" + languages[params[1]] + "&dt=t&q=" + URI::encode(params[0])
+        params = data.text.split(' ')
+        toLanguage = params[-1]
+        toTranslate = data.text.split(' en ')[0].split("enerbot como se dice ")[1]
+
+        if languages.keys.include? toLanguage and not toTranslate.to_s.empty?
+            url = "https://translate.googleapis.com/translate_a/single?client=gtx&sl=es&tl=" + languages[toLanguage] + "&dt=t&q=" + URI::encode(toTranslate)
             result = Net::HTTP.get(URI(url))
 
             translated = JSON.parse(result)[0][0][0]
             <<~HEREDOC
-                #{translated} #{flags[params[1]]}
+                #{translated} #{flags[toLanguage]}
             HEREDOC
         else
             "https://cdn.memegenerator.es/imagenes/memes/full/22/4/22044287.jpg"

--- a/scripts/lingo.rb
+++ b/scripts/lingo.rb
@@ -11,9 +11,10 @@ module Lingo
         flags =  {"ingles" => ":uk:", "español" => ":es:", "frances" => ":fr:", "portugues" => ":flag-pt:", "ruso" => ":ru:", "aleman" => ":de:",
             "chino" => ":flag-cn:", "japones" => ":jp:", "italiano" => ":it:", "argentino" => ":ar:", "chileno" => ":flag-cl:", "brasileño" => ":flag-br:"}
 
-        params = data.text.split(' ')
-        toLanguage = params[-1]
-        toTranslate = data.text.split(' en: ')[0].split("enerbot como se dice ")[1]
+        toTranslate, toLanguage = '',''
+        if match = data.text.match(/enerbot como se dice (.*) en (.*?)$/i)
+            toTranslate, toLanguage = match.captures
+        end
 
         if languages.keys.include? toLanguage and not toTranslate.to_s.empty?
             url = "https://translate.googleapis.com/translate_a/single?client=gtx&sl=es&tl=" + languages[toLanguage] + "&dt=t&q=" + URI::encode(toTranslate)


### PR DESCRIPTION
Arreglos de manejo de input, basado en módulo **"Rand"**

Ahora entendí que llega todo el texto al módulo.
Ej: _**enerbot como se dice perro verde en ruso**_ -> todo eso llega al módulo por lo tanto hay que hacer split y parse de "todo".

Nota: Solicite token de slack, aun no lo tengo así que no pude probar, pero ahora debería estar todo ok, con mejores validaciones de input.